### PR TITLE
Fixed release_comment default value in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ after 'deploy:finishing', 'github:releases:add_comment'
 
 Set capistrano variables with `set name, value`.
 
-Name            | Default                                          | Description
-----            | -------                                          | -----------
-release_tag     | `Time.now.strftime('release-%Y%m%d-%H%M')`       | Create releases when git-tag name
-release_comment | This pull-request deployed to production and ... | Pull requests to deploy report comment
+Name            | Default                                             | Description
+----            | -------                                             | -----------
+release_tag     | `Time.now.strftime('release-%Y%m%d-%H%M')`          | Create releases when git-tag name
+release_comment | I deployed this with production environment and ... | Pull requests to deploy report comment
 
 ### GitHub Enterprise
 


### PR DESCRIPTION
It's great job, capistrano-github-releases ! I will use this.
So, I found a mistake in README, and fixed release_comment default value.
please check it.
