### PR TITLE
Allows for multi-line release bodies

### DIFF
--- a/lib/capistrano/tasks/github_releases.rake
+++ b/lib/capistrano/tasks/github_releases.rake
@@ -63,11 +63,7 @@ namespace :github do
         default_body
       end
     }
-
-    grades = ask( "Enter test scores (or a blank line to quit):",
-                  lambda { |ans| ans =~ /^-?\d+$/ ? Integer(ans) : ans} ) do |q|
-      q.gather = ""
-    end
+    
     set :pull_request_id, -> {
       id = nil
 

--- a/lib/capistrano/tasks/github_releases.rake
+++ b/lib/capistrano/tasks/github_releases.rake
@@ -63,7 +63,7 @@ namespace :github do
         default_body
       end
     }
-    
+
     set :pull_request_id, -> {
       id = nil
 

--- a/lib/capistrano/tasks/github_releases.rake
+++ b/lib/capistrano/tasks/github_releases.rake
@@ -55,13 +55,19 @@ namespace :github do
       MD
 
       if fetch(:ask_release)
-        body = HighLine.new.ask("Release Body?")
-        "#{body + "\n" unless body.empty?}#{default_body}"
+        body = HighLine.new.ask("Release Body?") do |q|
+          q.gather = ''
+        end
+        "#{body.join("\n") + "\n" unless body.empty?}#{default_body}"
       else
         default_body
       end
     }
 
+    grades = ask( "Enter test scores (or a blank line to quit):",
+                  lambda { |ans| ans =~ /^-?\d+$/ ? Integer(ans) : ans} ) do |q|
+      q.gather = ""
+    end
     set :pull_request_id, -> {
       id = nil
 

--- a/lib/capistrano/tasks/github_releases.rake
+++ b/lib/capistrano/tasks/github_releases.rake
@@ -58,7 +58,7 @@ namespace :github do
         body = HighLine.new.ask("Release Body?") do |q|
           q.gather = ''
         end
-        "#{body.join("\n") + "\n" unless body.empty?}#{default_body}"
+        "#{body.join("\n") + "\n" unless body.empty?}\n#{default_body}"
       else
         default_body
       end


### PR DESCRIPTION
A blank line ends input. In our use case, it made sense to have a single line title but multi line release notes.
