### PR TITLE
Fix the link for gem version image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ $ bundle exec cap production github:releases:create # Auto creation by last pull
 $ bundle exec cap production github:releases:add_comment # Auto comment to last pull-request
 ```
 
-[![Gem version](https://img.shields.io/gem/v/capistrano-github-releases.svg?style=flat-square)][gem]
-[gem]: https://rubygems.org/gems/capistrano-github-releases
+[![Gem version](https://img.shields.io/gem/v/capistrano-github-releases.svg?style=flat-square)](https://rubygems.org/gems/capistrano-github-releases)
 
 Installation
 ------------


### PR DESCRIPTION
Hello, Thanks for developing the great gem! I am using this on my work.

I found that the markdown code was shown around gem version image on README. I fixed the markdown so could you review this?

### Before
![image](https://cloud.githubusercontent.com/assets/1726225/25948519/c889adde-368e-11e7-9c75-1bacbe5459d9.png)

### After

![image](https://cloud.githubusercontent.com/assets/1726225/25948532/d980bc5e-368e-11e7-809e-12ebaca0c331.png)

And fixed the link!